### PR TITLE
Removed invalid link - M365Security Book.

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,6 @@ Community books, both physical and ebooks.
 - [Azure Security](https://www.manning.com/books/azure-security-2)
 - [Cloud Observability with Azure Monitor](https://www.packtpub.com/en-us/product/cloud-observability-with-azure-monitor-9781835881194)
 - [Cloud Solution Architect's Career Master Plan: Proven techniques and effective tips to help you become a successful solution architect](https://www.amazon.com/Cloud-Solution-Architects-Career-Master/dp/1805129716)
-- [Microsoft 365 Security for IT Pros](https://m365securitybook.com/)
 
 ### Community Articles
 


### PR DESCRIPTION
This pull request includes a minor change to the `README.md` file. The change removes the link to the "Microsoft 365 Security for IT Pros" book from the list of community books.

Content update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L308): Removed the link to "Microsoft 365 Security for IT Pros" from the community books section.Removed invalid link - M365Security Book.