### PR TITLE
Update markdown-link-checker.yml

### DIFF
--- a/.github/workflows/markdown-link-checker.yml
+++ b/.github/workflows/markdown-link-checker.yml
@@ -3,9 +3,9 @@ name: Markdown Link Checker
 on: 
   push:
     branches: ['*']
-  schedule:
+ # schedule:
   # Run every day at 9:00 AM (See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07)
-  - cron: "0 9 * * *"
+ # - cron: "0 9 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/markdown-link-checker.yml` file. The change comments out the scheduled run configuration for the Markdown Link Checker workflow.

* [`.github/workflows/markdown-link-checker.yml`](diffhunk://#diff-1ed0962fc85aeca641b7c78d876b367b71e36b968bc389171487f10d8752e0ffL6-R8): Commented out the schedule configuration that runs the workflow every day at 9:00 AM.