### PR TITLE
Add AzureNamer to Community Repositories and Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ Community-created tools and repositories.
 - [Azure IP Ranges](https://azureipranges.azurewebsites.net/)
 - [Azure Local Hands-on-lab guides](https://github.com/DellGEOS/AzureStackHOLs)
 - [Must Learn KQL - the series, the book, the merch store](https://github.com/rod-trent/MustLearnKQL)
+- [AzureNamer - CAF compliant Azure resource name generator](https://azurenamingconventions.com/)
 - [Azure Network Latency Dashboard](https://latency.azure.cloud63.fr/)
 - [Azure permissions reference](https://azure.permissions.cloud/)
 - [Microsoft Portals](https://msportals.io/)


### PR DESCRIPTION
Adds **AzureNamer**, a free CAF compliant Azure resource name generator covering 204 Azure resource types, with one-click export to Terraform, Bicep, and CSV, a reverse name parser, and a searchable abbreviations reference. No login, and it runs entirely in the browser.

It fits alongside the existing Azure Naming Tool and the naming-convention resources already in this list.

Disclosure: I am the author. Placed alphabetically in "Community Repositories and Tools", happy to move it if you prefer a different spot.

https://azurenamingconventions.com
